### PR TITLE
Allow running only the basecalling subworkflow

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -41,8 +41,8 @@ workflow {
     Map colors = NfcoreTemplate.logColours(params.monochrome_logs)
 
     can_start = true
-    if (!params.snp && !params.sv && !params.methyl && !params.cnv && !params.str) {
-        log.error (colors.red + "No work to be done! Choose one or more workflows to run from [--snp, --sv, --cnv, --str, --methyl]" + colors.reset)
+    if (!params.fast5_dir && !params.snp && !params.sv && !params.methyl && !params.cnv && !params.str) {
+        log.error (colors.red + "No work to be done! Choose one or more workflows to run from [--fast5_dir, --snp, --sv, --cnv, --str, --methyl]" + colors.reset)
         can_start = false
     }
 


### PR DESCRIPTION
The pipeline does not allow the user to run the basecalling subworkflow in isolation, despite the README stating that

> The basecalling, SNP, SV, 5mC aggregation, and CNV workflows are all independent and can be run in isolation or together using options to activate them.

I did not observe any issues when I test-ran of a pipeline modified to allow this.