### PR TITLE
Include index filename in filtered bam for wf_human_sv

### DIFF
--- a/modules/local/wf-human-sv.nf
+++ b/modules/local/wf-human-sv.nf
@@ -12,7 +12,7 @@ process filterBam {
         tuple path("${params.sample_name}.filtered.${xam_fmt}"), path("${params.sample_name}.filtered.${xam_fmt}.${xai_fmt}"), emit: xam
     script:
     """
-    samtools view -@ $task.cpus -F 2308 -o ${params.sample_name}.filtered.${xam_fmt} -O ${xam_fmt} --write-index ${xam} --reference ${ref}
+    samtools view -@ $task.cpus -F 2308 -o ${params.sample_name}.filtered.${xam_fmt}##idx##${params.sample_name}.filtered.${xam_fmt}.${xai_fmt} -O ${xam_fmt} --write-index ${xam} --reference ${ref}
     """
 }
 


### PR DESCRIPTION
As the samtools manual states, "By default SAM and BAM will use CSI indices while CRAM will use CRAI indices". Thus, no `....filtered.bam.bai` is created as expected by the workflow leading to an error:
```
Missing output file(s) `....filtered.bam.bai` expected by process `sv:variantCall:filterBam (1)`
```
Using the `filename##idx##indexname` notation as explained by the samtools manual fixes that.