### PR TITLE
Fix tr_bed parameter handling

### DIFF
--- a/workflows/wf-human-sv.nf
+++ b/workflows/wf-human-sv.nf
@@ -135,10 +135,10 @@ workflow variantCall {
     main:
 
         // tandom_repeat bed
-        if(params.tr_bed == null) {
-            tr_bed = optional_file
-        } else {
+        if(params.tr_bed) {
             tr_bed = Channel.fromPath(params.tr_bed, checkIfExists: true)
+        } else {
+            tr_bed = optional_file
         }
 
         if (!genome_build) {


### PR DESCRIPTION
Hello,

I've identified an issue with the handling of the `tr_bed` parameter that deviates from the standard practice seen in other parts of the codebase (for example, [this line](https://github.com/epi2me-labs/wf-human-variation/blob/018ff7180271d21682a9f2e76244564609083bef/main.nf#L106)).

When the `tr_bed` parameter is provided as an empty string in the `params-file.json`, it causes an error:
```json
"tr_bed": "",
```

This pull request addresses this issue by ensuring proper handling of the tr_bed parameter when it is an empty string.

Thank you for your great work and hope this helps!

Best regards,
Blaž