### PR TITLE
Sort haplotagged file collection

### DIFF
--- a/.github/workflows/issue-autoreply.yml
+++ b/.github/workflows/issue-autoreply.yml
@@ -1,0 +1,9 @@
+name: Issue Auto-Reply
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-reply:
+    uses: epi2me-labs/.github/.github/workflows/issue-autoreply.yml@main

--- a/workflows/wf-human-snp.nf
+++ b/workflows/wf-human-snp.nf
@@ -182,7 +182,7 @@ workflow snp {
             // get a file of sequence names for all SQ that were haplotagged by post_clair_contig_haplotag
             haplotagged_fosn = \
                 haplotagged_ctg_bams.map{ meta, contig, xam, xai -> contig }
-                | collectFile(name: "haplotagged.fosn", newLine: true, sort: false)
+                | collectFile(name: "haplotagged.fosn", newLine: true, sort: true)
             // we'll take this file of haplotagged contigs and pull out a
             //  subset BAM for each SQ in the input XAM that does not appear
             //  as well as a bonus BAM for unaligned reads. we'll mix this


### PR DESCRIPTION
Without sorting this process will be rerun everytime. Changing it to true enables the resuming process to work again.